### PR TITLE
[stable/jenkins] Create agent-jcasc template to configure multiple agents

### DIFF
--- a/stable/jenkins/CHANGELOG.md
+++ b/stable/jenkins/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 NOTE: The change log until version 1.5.7 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
 
+## 1.9.25
+
+Add template `agent-jcasc` to allow multiple agents to be defined via JCasC.
+
 ## 1.9.24
 
 Update JCasC auto-reload docs and remove stale ssh key references from version "1.8.0 JCasC auto reload works without ssh keys"

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -380,21 +380,18 @@ rbac:
 
 Below is an example of a `values.yaml` file which creates multiple agents via JCasC. Agents can be defined as arrays and/or objects.
 
-Note: The `agentList`, `agentHierarchy.maven`, and `baseAgent` names can be changed along with the corresponding references in the JCasC.
+Note: The `agentList`, `agentHierarchy.node`, `agentHierarchy.python`, and `baseAgent` names are arbitrary and can be changed along with the corresponding references in the JCasC.
 
 ```yaml
 agent:
   enabled: true
   podName: default
   resources:
-    requests:
-      cpu: 1024m
-      memory: 2048Mi
     limits:
       cpu: 1024m
       memory: 2048Mi
 
-# A list of agents. Each entry corresponds to a chart `agent` in terms of the values that can be set.
+# A list of agents. Each entry corresponds to a chart `agent` in terms of the configurable values.
 agentList:
 - podName: maven
   image: jenkins/jnlp-agent-maven
@@ -402,11 +399,11 @@ agentList:
   inheritFrom: maven
   resources:
     limits:
-      cpu: 1024m
+      cpu: 2048m
       memory: 4096Mi
 
-# A hierarchy of agents. Useful when creating a custom chart to allow values to be overridden.
-# Each object corresponds to a chart `agent` in terms of the values that can be set.
+# A hierarchy of agents. Useful when creating a custom chart to allow individual values to be overridden.
+# Each object corresponds to a chart `agent` in terms of the configurable values.
 agentHierarchy:
   node:
     podName: node

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -206,9 +206,10 @@ Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload 
 | `agent.privileged`         | Agent privileged container                      | `false`                |
 | `agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 512m, memory: 512Mi}, limits: {cpu: 512m, memory: 512Mi}}`|
 | `agent.volumes`            | Additional volumes                              | `[]`                   |
+| `agent.podRetention`       | Agent Pod retention after build completes       | `Never`       |
 | `agent.envVars`            | Environment variables for the agent Pod         | `[]`                   |
 | `agent.command`            | Executed command when side container starts     | Not set                |
-| `agent.args`               | Arguments passed to executed command            | Not set                |
+| `agent.args`               | Arguments passed to executed command            | `${computer.jnlpmac} ${computer.name}`|
 | `agent.sideContainerName`  | Side container name in agent                    | jnlp                   |
 | `agent.TTYEnabled`         | Allocate pseudo tty to the side container       | false                  |
 | `agent.containerCap`       | Maximum number of agent                         | 10                     |
@@ -216,6 +217,7 @@ Some third-party systems, e.g. GitHub, use HTML-formatted data in their payload 
 | `agent.idleMinutes`        | Allows the Pod to remain active for reuse       | 0                      |
 | `agent.yamlTemplate`       | The raw yaml of a Pod API Object to merge into the agent spec | Not set                |
 | `agent.slaveConnectTimeout`| Timeout in seconds for an agent to be online    | 100                    |
+| `agent.workingDir`         | Working directory                               | `/home/jenkins`        |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
@@ -385,6 +387,9 @@ agent:
   enabled: true
   podName: default
   resources:
+    requests:
+      cpu: 1024m
+      memory: 2048Mi
     limits:
       cpu: 1024m
       memory: 2048Mi
@@ -396,12 +401,9 @@ agentList:
 - podName: maven-large
   inheritFrom: maven
   resources:
-    requests:
-      cpu: 1024m
-      memory: 2048Mi
     limits:
       cpu: 1024m
-      memory: 2048Mi
+      memory: 4096Mi
 
 # A hierarchy of agents. Useful when creating a custom chart to allow values to be overridden.
 # Each object corresponds to a chart `agent` in terms of the values that can be set.
@@ -430,7 +432,8 @@ master:
                 {{- range .Values.agentList }}
                 {{- tpl (include "jenkins.agent-jcasc" (set $ "Values" (set $.Values "agent" .))) $ | nindent 6 }}
                 {{- end }}
-                {{- tpl (include "jenkins.agent-jcasc" (set . "Values" (set .Values "agent" .Values.agentHierarchy.maven))) . | nindent 6 }}
+                {{- tpl (include "jenkins.agent-jcasc" (set . "Values" (set .Values "agent" .Values.agentHierarchy.node))) . | nindent 6 }}
+                {{- tpl (include "jenkins.agent-jcasc" (set . "Values" (set .Values "agent" .Values.agentHierarchy.python))) . | nindent 6 }}
                 {{- $_ := set .Values "agent" $agent }}
 ```
 

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -101,7 +101,7 @@ jenkins:
       serverUrl: "https://kubernetes.default"
       {{- if .Values.agent.enabled }}
       templates:
-      {{- tpl ( include "jenkins.agent-jcasc" . ) . | nindent 6 }}
+      {{- include "jenkins.agent-jcasc" . | nindent 6 }}
       {{- end }}
   {{- if .Values.master.csrf.defaultCrumbIssuer.enabled }}
   crumbIssuer:
@@ -152,10 +152,15 @@ Create the name of the service account for Jenkins agents to use
 {{- end -}}
 {{- end -}}
 
+{{/*
+Returns agent configuration as code
+*/}}
 {{- define "jenkins.agent-jcasc" -}}
+{{- if .Values.agent.enabled -}}
 - name: "{{ .Values.agent.podName }}"
   containers:
-  - alwaysPullImage: {{ .Values.agent.alwaysPullImage }}
+  - name: "{{ .Values.agent.sideContainerName }}"
+    alwaysPullImage: {{ .Values.agent.alwaysPullImage }}
     {{- if .Values.agent.args }}
     args: "{{ .Values.agent.args }}"
     {{- else }}
@@ -173,7 +178,6 @@ Create the name of the service account for Jenkins agents to use
     {{- else }}
     image: "{{ .Values.agent.image }}:{{ .Values.agent.tag }}"
     {{- end }}
-    name: "{{ .Values.agent.sideContainerName }}"
     privileged: "{{- if .Values.agent.privileged }}true{{- else }}false{{- end }}"
     {{- if .Values.agent.resources }}
     {{- if .Values.agent.resources.limits }}
@@ -205,7 +209,8 @@ Create the name of the service account for Jenkins agents to use
   {{- end }}
   {{- if .Values.agent.yamlTemplate }}
   yaml: |-
-  {{- tpl .Values.agent.yamlTemplate . | nindent 4 }}
+  {{- tpl .Values.agent.yamlTemplate . | trim | nindent 4 }}
   {{- end }}
   yamlMergeStrategy: "override"
-{{- end }}
+{{- end -}}
+{{- end -}}

--- a/stable/jenkins/templates/_helpers.tpl
+++ b/stable/jenkins/templates/_helpers.tpl
@@ -101,6 +101,7 @@ jenkins:
       serverUrl: "https://kubernetes.default"
       {{- if .Values.agent.enabled }}
       templates:
+      {{- tpl ( include "jenkins.agent-jcasc" . ) . | nindent 6 }}
       {{- end }}
   {{- if .Values.master.csrf.defaultCrumbIssuer.enabled }}
   crumbIssuer:
@@ -160,7 +161,9 @@ Create the name of the service account for Jenkins agents to use
     {{- else }}
     args: "^${computer.jnlpmac} ^${computer.name}"
     {{- end }}
-    command: {{ .Values.agent.command | default "" | quote }}
+    {{- if not ( kindIs "invalid" .Values.agent.command ) }}
+    command: {{ .Values.agent.command | quote }}
+    {{- end }}
     envVars:
     - containerEnvVar:
         key: "JENKINS_URL"
@@ -202,7 +205,7 @@ Create the name of the service account for Jenkins agents to use
   {{- end }}
   {{- if .Values.agent.yamlTemplate }}
   yaml: |-
-  {{- .Values.agent.yamlTemplate | nindent 4 }}
+  {{- tpl .Values.agent.yamlTemplate . | nindent 4 }}
   {{- end }}
   yamlMergeStrategy: "override"
 {{- end }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -472,6 +472,7 @@ agent:
   #       value: "value"
   # Timeout in seconds for an agent to be online
   slaveConnectTimeout: 100
+  workingDir: "/home/jenkins"
 
 persistence:
   enabled: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
#### What this PR does / why we need it:
This PR provides the ability to configure multiple agents via JCasC. See the README for an example.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #20870

#### Special notes for your reviewer:
The pod template definition (`kubernetes.templates`) in template `jenkins.casc.defaults` is moved to a new `jenkins.agent-jcasc` template with the following modifications. See http://www.mergely.com/h9N9IvrT/?ws=1.

1. `name` fields moved to the top so they stand out 
1. `command` quoted when not nil to support empty string (empty string ensures Jenkins doesn't apply a default value such as `/bin/sh -c`)
1. empty checks added for `resources`, `resources.limits`, `resources.requests`, and `yamlTemplate`
1. `workingDir` parameterized
1. `volumes` added

I chose not to make use of the kubernetes plugin casc fields related to agent inheritance.

`defaultsProviderTemplate` - the agent from which all other agents inherit configuration  
Merging `agent` into the other agents in the JCasC allows all agents to make use of the chart's default configuration for `agent`. To wait for the kubernetes plugin to merge the values at runtime means each agent would need to set `sideContainerName` (so container values could be inherited) as well as set any fields which get assigned a default value when nil and thus aren't eligible for inheritance (e.g. `command` and `workingDir`).

`inheritFrom` - indicates from which agent this agent should inherit configuration
I thought an `agent.inheritFrom` field would look out of place in the chart since the chart only defines a single agent.

# `helm template` tests
for helm 2 use `--execute` instead of `--show-only`
## auto-reload
### default JCasC config
```
helm template stable/jenkins \
--show-only templates/jcasc-config.yaml \
--set master.sidecars.configAutoReload.enabled=true \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=true
```
### JCasC ConfigScripts
stable/jenkins/agent-values.yaml contains the example from the README
```
helm template stable/jenkins \
--show-only templates/jcasc-config.yaml \
--set master.sidecars.configAutoReload.enabled=true \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=false \
--values stable/jenkins/agent-values.yaml
```
## NO auto-reload
### default JCasC config
```
helm template stable/jenkins \
--show-only templates/config.yaml \
--set master.sidecars.configAutoReload.enabled=false \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=true
```
### JCasC ConfigScripts
stable/jenkins/agent-values.yaml contains the example from the README
```
helm template stable/jenkins \
--show-only templates/config.yaml \
--set master.sidecars.configAutoReload.enabled=false \
--set master.JCasC.enabled=true \
--set master.JCasC.defaultConfig=false \
--values stable/jenkins/agent-values.yaml
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
